### PR TITLE
Fix docker build to include necessary CA Certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM golang:buster as builder
 
+RUN apt-get update && apt-get install ca-certificates
+
 WORKDIR /app
 
 COPY go.mod .
@@ -14,6 +16,10 @@ RUN go test -covermode=atomic -coverpkg=all ./...
 RUN CGO_ENABLED=0 GOOS=linux go build
 
 FROM scratch
+
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
 
 COPY --from=builder /app/statusinator /app/
 ENTRYPOINT ["/app/statusinator"]


### PR DESCRIPTION
Closes #2 

Docker run results:
```
{
  "CommonPrefixes": null,
  "Contents": [
    {
      "ETag": "\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"",
      "Key": "xxxxxxxx",
      "LastModified": "2020-02-08T21:50:31Z",
      "Owner": null,
      "Size": 9,
      "StorageClass": "STANDARD"
    }
  ],
  "ContinuationToken": null,
  "Delimiter": null,
  "EncodingType": null,
  "IsTruncated": false,
  "KeyCount": 1,
  "MaxKeys": 2,
  "Name": "xxxxxxxx",
  "NextContinuationToken": null,
  "Prefix": "",
  "StartAfter": null
}
```